### PR TITLE
Hotfix: Correct licence on published `ies-common` specification files

### DIFF
--- a/docs/specification/ies-common.md
+++ b/docs/specification/ies-common.md
@@ -83,7 +83,7 @@ rapper -i turtle -o ntriples ies-common.ttl > ies-common.nt
 | **Modified** | 2026-03-30                                               |
 | **Publisher** | UK Department for Business and Trade                     |
 | **Language** | en-GB (British English)                                  |
-| **Licence** | NDTP Inner Source                                        |
+| **Licence** | MIT Licence                                              |
 | **Namespace** | `http://informationexchangestandard.org/ont/ies/common/` |
 | **Preferred Prefix** | `ies`                                                    |
 

--- a/docs/specification/ies-common.ttl
+++ b/docs/specification/ies-common.ttl
@@ -1,79 +1,34 @@
-# NDTP InnerSource License
+# MIT License
 #
-# Repository: `private-ospo-resources`
+# Repository: `Information Exchange Standard (IES)`
 # Description: `Defines the licensing terms for the source code in this repository.`
-#
-# Version
-#
-# NDTP InnerSource License – Version 1.0
-# Issued by: National Digital Twin Programme (NDTP)
-# Effective Date: 9 July 2025
 #
 # Copyright
 #
 # © Crown Copyright 2026.
-# This work has been developed by the **National Digital Twin Programme (NDTP)** and is legally attributed to the **Department for Business and Trade (UK)** as the governing entity.
+# This work forms part of the Information Exchange Standard initiative and is currently under the
+# custodianship of the Department for Business and Trade (UK), acting on behalf of a cross-government
+# group of stakeholders. This code is licensed under the MIT License.
 #
-# This repository is **not open source**.
-# Its contents are licensed under the terms of this **NDTP InnerSource License**, unless and until it is formally published under an approved open source licence by the NDTP Management Team.
+# Note: All documentation in this repository is licensed under the Open Government Licence v3.0
+# (OGL-3.0). For full terms, see OGL_LICENSE.md.
 #
-# 1. Purpose
+# MIT License
 #
-# This repository supports InnerSource development practices within the NDTP. It enables collaborative development by internal teams and authorised suppliers, in a controlled and non-public environment.
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+# associated documentation files (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge, publish, distribute,
+# sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 #
-# 2. Licensing Status
+# The above copyright notice and this permission notice shall be included in all copies or
+# substantial portions of the Software.
 #
-# This work is **not licensed under an open source licence**.
-# It must not be published, distributed, sublicensed, or shared externally without the **explicit, written approval** of the NDTP Management Team.
-#
-# The NDTP InnerSource Licence permits internal collaboration only. No part of this repository may be used or disclosed beyond the authorised delivery context.
-#
-# 3. Intellectual Property
-#
-# All rights, including intellectual property rights in this code and associated materials, are owned by the NDTP.
-#
-# Where contributions are made by suppliers or delivery partners, those contributions are accepted on the basis that **full intellectual property rights** belong to the Crown under the terms of their contract.
-#
-# 4. Permitted Use
-#
-# You may:
-#
-# - View, use, and modify the code as required to fulfil your responsibilities under the NDTP.
-# - Collaborate within authorised NDTP teams and with approved suppliers under existing contracts.
-#
-# You may not:
-#
-# - Share, publish, or release this repository publicly.
-# - Fork, clone, or redistribute this code outside approved NDTP channels.
-# - Apply any license other than the NDTP InnerSource License to this repository or its contents, unless instructed by the NDTP Management Team.
-#
-# 5. Future Publication
-#
-# At the discretion of the NDTP Management Team, this repository may later be designated for release under an approved open source licence.
-#
-# Any such designation must follow NDTP's internal governance processes.
-#
-# Until such designation is explicitly made and executed, this repository remains **confidential and proprietary**.
-#
-# 6. Enforcement
-#
-# Any unauthorised disclosure, publication, or redistribution of this repository or its contents may:
-#
-# - Constitute a breach of contract
-# - Trigger formal investigation
-# - Result in legal, disciplinary, or commercial action, including revocation of access rights
-#
-# All actions will be escalated to the NDTP Management Team for appropriate handling.
-#
-# Contact
-#
-# For all enquiries regarding licensing, publication status, or contributor rights, please contact:
-#
-# NDTP Management Team
-# Department for Business and Trade (UK)
-# NDTP@BUSINESSANDTRADE.GOV.UK
-#
-# End of NDTP InnerSource Licence – Version 1.0
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+# NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+# OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #----------------------------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
# Hotfix: Correct licence on published `ies-common` specification files

**Branch:** `hotfix/fix-license` → `main`

## Summary

The published specification files in `docs/specification/` carried the **NDTP InnerSource License**, which is incorrect for this public release. Per [`LICENSE.md`](LICENSE.md), the ontology source is licensed under the **MIT License**. The InnerSource licence explicitly states the work is *"not open source"* and *"must not be published"* — directly contradicting the published state of this repository.

## Changes

**`docs/specification/ies-common.ttl`**
- Replaced the NDTP InnerSource License header block with an MIT License header consistent with `LICENSE.md`.
- Corrected the stale `Repository: \`private-ospo-resources\`` reference to `Information Exchange Standard (IES)`.

**`docs/specification/ies-common.md`**
- Updated the metadata table licence from `NDTP Inner Source` to `MIT Licence`. The document footer already stated MIT, so the file is now internally consistent.

## Why this is a hotfix

This is a licensing compliance error on a publicly released artefact. The stated licence forbids public distribution, so the published files misrepresented the terms under which IES is being made available. It should be merged ahead of the normal release cycle.

## Acceptance criteria

- [x] `ies-common.ttl` header reflects the MIT License consistent with `LICENSE.md`
- [x] `ies-common.md` metadata table shows `MIT Licence`
- [x] No other licence references in `docs/specification/` still cite NDTP InnerSource
